### PR TITLE
Introduce shared state manager module

### DIFF
--- a/index.html
+++ b/index.html
@@ -470,22 +470,12 @@
     </div>
     <script src="layout-designer.js"></script>
     <script src="products.js"></script>
+    <script src="state-manager.js"></script>
     <script>
         // --- DATA ---
-        window.configuration = { 
-            projectName: '',
-            racks: [],
-            cloudServers: [],
-            cloudCameras: [],
-            allInOneCameras: [],
-            accessControl: [],
-            mounts: [],
-            accessories: [],
-            customParts: [],
-            cameraLayout: null,
-            layoutPlacements: []
-        };
-        
+        window.configuration = window.AppState.createInitialConfiguration(window.configuration);
+        const configuration = window.configuration;
+
         let autoAddLicenses = true;
 
         const smbkBundles = {
@@ -2033,8 +2023,8 @@
 
         function resetConfiguration() {
             if(confirm('Are you sure you want to reset the entire configuration?')) {
-                configuration = { racks: [], cloudServers: [], cloudCameras: [], allInOneCameras: [], accessControl: [], mounts: [], accessories: [], customParts: [], cameraLayout: null, layoutPlacements: [] };
-                localStorage.removeItem('3xlogicConfig');
+                window.AppState.resetConfiguration(configuration);
+                localStorage.removeItem(window.AppState.STORAGE_KEY);
                 renderAll();
             }
         }
@@ -2048,84 +2038,16 @@
 
         // --- SAVE, LOAD, & LOCAL STORAGE ---
         function saveToLocalStorage() {
-            try {
-                const configString = JSON.stringify(configuration);
-                localStorage.setItem('3xlogicConfig', configString);
-            } catch (e) {
-                console.error("Failed to save to localStorage", e);
-            }
+            window.AppState.persistConfiguration(configuration);
         }
 
         function loadFromLocalStorage() {
-  // Small helpers to make sure we always work with arrays/objects
-  const toArray = (v) => {
-    if (Array.isArray(v)) return v;
-    if (v && typeof v === 'object') return Object.values(v); // migrate object maps -> arrays
-    return [];
-  };
-  const toObject = (v) => (v && typeof v === 'object' && !Array.isArray(v) ? v : {});
-
-  try {
-    const configString = localStorage.getItem('3xlogicConfig');
-    if (!configString) return false;
-
-    const loadedConfig = toObject(JSON.parse(configString));
-
-    // IMPORTANT: mutate the existing configuration object instead of replacing it,
-    // so other modules holding a reference don't break.
-    Object.assign(configuration, { layoutPlacements: [] }, loadedConfig);
-
-    // Normalize top-level collections
-    configuration.racks            = toArray(configuration.racks);
-    configuration.cloudServers     = toArray(configuration.cloudServers);
-    configuration.cloudCameras     = toArray(configuration.cloudCameras);
-    configuration.allInOneCameras  = toArray(configuration.allInOneCameras);
-    configuration.cameraLayout     = configuration.cameraLayout || null;
-
-    // Normalize nested racks/devices/cameras and NVR fields
-    configuration.racks.forEach((r) => {
-      r.standaloneSwitches = toArray(r.standaloneSwitches);
-      r.devices            = toArray(r.devices);
-
-      r.devices.forEach((d) => {
-        d.assignedUps = toArray(d.assignedUps);
-        d.cameras     = toArray(d.cameras);
-
-        if (d.product && d.product.deviceType === 'nvr') {
-          d.licenses = toArray(d.licenses);
-          if (typeof syncNvrLicenses === 'function') {
-            syncNvrLicenses(d);
-          }
+            return window.AppState.restoreConfiguration(configuration, {
+                syncNvrLicenses,
+                onSuccess: () => showToast('Project restored from last session.'),
+                onError: (error) => console.error('Failed to load from localStorage', error)
+            });
         }
-      });
-    });
-
-    // Fix/seed camera fields across ALL camera arrays (cloud / AIO / on-recorders)
-    const rackCameras = configuration.racks.flatMap((r) =>
-      r.devices.flatMap((d) => toArray(d.cameras))
-    );
-
-    const allCameraArrays = [configuration.cloudCameras, configuration.allInOneCameras, rackCameras];
-
-    allCameraArrays.forEach((camArray) => {
-      // Each member here is GUARANTEED an array now
-      camArray.forEach((c) => {
-        if (typeof c.location === 'undefined') c.location = '';
-        if (typeof c.quantity === 'undefined') c.quantity = 1;
-        if (c.isCloud && typeof c.selectedMounts === 'undefined') c.selectedMounts = [null];
-      });
-    });
-
-    if (typeof showToast === 'function') {
-      showToast('Project restored from last session.');
-    }
-    return true;
-  } catch (e) {
-    console.error('Failed to load from localStorage', e);
-    localStorage.removeItem('3xlogicConfig');
-    return false;
-  }
-}
 
         function saveProjectToFile() {
             const configString = JSON.stringify(configuration, null, 2);
@@ -2150,10 +2072,9 @@
                 try {
                     const configString = e.target.result;
                     const loadedConfig = JSON.parse(configString);
-                    configuration = {
-                        layoutPlacements: [],
-                        ...loadedConfig
-                    };
+                    window.AppState.applyDefaults(configuration);
+                    Object.assign(configuration, { layoutPlacements: [] }, loadedConfig);
+                    window.AppState.normalizeConfiguration(configuration, { syncNvrLicenses });
                     renderAll();
                     showToast("Project Loaded Successfully!");
                 } catch (err) {

--- a/state-manager.js
+++ b/state-manager.js
@@ -1,0 +1,162 @@
+(function(global) {
+  const STORAGE_KEY = '3xlogicConfig';
+
+  const DEFAULT_CONFIGURATION = {
+    projectName: '',
+    racks: [],
+    cloudServers: [],
+    cloudCameras: [],
+    allInOneCameras: [],
+    accessControl: [],
+    mounts: [],
+    accessories: [],
+    customParts: [],
+    cameraLayout: null,
+    layoutPlacements: [],
+    layoutWalls: []
+  };
+
+  function cloneDefaults() {
+    return JSON.parse(JSON.stringify(DEFAULT_CONFIGURATION));
+  }
+
+  function applyDefaults(target) {
+    const base = typeof target === 'object' && target !== null ? target : {};
+    const defaults = cloneDefaults();
+
+    Object.keys(base).forEach((key) => {
+      if (!Object.prototype.hasOwnProperty.call(defaults, key)) {
+        delete base[key];
+      }
+    });
+
+    return Object.assign(base, defaults);
+  }
+
+  function toArray(value) {
+    if (Array.isArray(value)) return value;
+    if (value && typeof value === 'object') return Object.values(value);
+    return [];
+  }
+
+  function ensureCameraDefaults(camera) {
+    if (!camera || typeof camera !== 'object') return;
+    if (typeof camera.location === 'undefined') camera.location = '';
+    if (typeof camera.quantity === 'undefined') camera.quantity = 1;
+    if (camera.isCloud && typeof camera.selectedMounts === 'undefined') {
+      camera.selectedMounts = [null];
+    }
+  }
+
+  function normalizeConfiguration(configuration, { syncNvrLicenses } = {}) {
+    configuration.projectName = configuration.projectName || '';
+    configuration.cameraLayout = configuration.cameraLayout || null;
+
+    configuration.racks = toArray(configuration.racks);
+    configuration.cloudServers = toArray(configuration.cloudServers);
+    configuration.cloudCameras = toArray(configuration.cloudCameras);
+    configuration.allInOneCameras = toArray(configuration.allInOneCameras);
+    configuration.accessControl = toArray(configuration.accessControl);
+    configuration.mounts = toArray(configuration.mounts);
+    configuration.accessories = toArray(configuration.accessories);
+    configuration.customParts = toArray(configuration.customParts);
+    configuration.layoutPlacements = toArray(configuration.layoutPlacements);
+    configuration.layoutWalls = toArray(configuration.layoutWalls);
+
+    configuration.racks.forEach((rack) => {
+      rack.standaloneSwitches = toArray(rack.standaloneSwitches);
+      rack.devices = toArray(rack.devices);
+
+      rack.devices.forEach((device) => {
+        device.assignedUps = toArray(device.assignedUps);
+        device.cameras = toArray(device.cameras);
+        device.storage = toArray(device.storage);
+        device.licenses = toArray(device.licenses);
+        device.poeSwitches = toArray(device.poeSwitches);
+        device.doors = toArray(device.doors);
+
+        if (device.product && device.product.deviceType === 'nvr' && typeof syncNvrLicenses === 'function') {
+          syncNvrLicenses(device);
+        }
+
+        device.cameras.forEach(ensureCameraDefaults);
+      });
+    });
+
+    const rackCameras = configuration.racks.flatMap((rack) =>
+      rack.devices.flatMap((device) => device.cameras || [])
+    );
+
+    [configuration.cloudCameras, configuration.allInOneCameras, rackCameras].forEach((collection) => {
+      collection.forEach(ensureCameraDefaults);
+    });
+
+    return configuration;
+  }
+
+  function createInitialConfiguration(existing) {
+    const target = applyDefaults(existing);
+    return normalizeConfiguration(target);
+  }
+
+  function resetConfiguration(configuration) {
+    applyDefaults(configuration);
+    normalizeConfiguration(configuration);
+    return configuration;
+  }
+
+  function persistConfiguration(configuration, storageKey = STORAGE_KEY) {
+    try {
+      const configString = JSON.stringify(configuration);
+      localStorage.setItem(storageKey, configString);
+      return true;
+    } catch (error) {
+      console.error('Failed to save to localStorage', error);
+      return false;
+    }
+  }
+
+  function restoreConfiguration(configuration, {
+    storageKey = STORAGE_KEY,
+    syncNvrLicenses,
+    onSuccess,
+    onError
+  } = {}) {
+    try {
+      const configString = localStorage.getItem(storageKey);
+      if (!configString) return false;
+
+      const parsedConfig = JSON.parse(configString);
+      if (!parsedConfig || typeof parsedConfig !== 'object') return false;
+
+      applyDefaults(configuration);
+      Object.assign(configuration, parsedConfig);
+      normalizeConfiguration(configuration, { syncNvrLicenses });
+
+      if (typeof onSuccess === 'function') {
+        onSuccess(configuration);
+      }
+
+      return true;
+    } catch (error) {
+      localStorage.removeItem(storageKey);
+      if (typeof onError === 'function') {
+        onError(error);
+      } else {
+        console.error('Failed to load from localStorage', error);
+      }
+      return false;
+    }
+  }
+
+  global.AppState = {
+    STORAGE_KEY,
+    DEFAULT_CONFIGURATION,
+    createInitialConfiguration,
+    resetConfiguration,
+    persistConfiguration,
+    restoreConfiguration,
+    normalizeConfiguration,
+    applyDefaults
+  };
+})(window);

--- a/vigilconfig/index.html
+++ b/vigilconfig/index.html
@@ -470,21 +470,11 @@
     </div>
     <script src="layout-designer.js"></script>
     <script src="products.js"></script>
+    <script src="state-manager.js"></script>
     <script>
         // --- DATA ---
-        window.configuration = { 
-            projectName: '',
-            racks: [],
-            cloudServers: [],
-            cloudCameras: [],
-            allInOneCameras: [],
-            accessControl: [],
-            mounts: [],
-            accessories: [],
-            customParts: [],
-            cameraLayout: null,
-            layoutPlacements: []
-        };
+        window.configuration = window.AppState.createInitialConfiguration(window.configuration);
+        const configuration = window.configuration;
         
         let autoAddLicenses = true;
 
@@ -2033,8 +2023,8 @@
 
         function resetConfiguration() {
             if(confirm('Are you sure you want to reset the entire configuration?')) {
-                configuration = { racks: [], cloudServers: [], cloudCameras: [], allInOneCameras: [], accessControl: [], mounts: [], accessories: [], customParts: [], cameraLayout: null, layoutPlacements: [] };
-                localStorage.removeItem('3xlogicConfig');
+                window.AppState.resetConfiguration(configuration);
+                localStorage.removeItem(window.AppState.STORAGE_KEY);
                 renderAll();
             }
         }
@@ -2048,84 +2038,16 @@
 
         // --- SAVE, LOAD, & LOCAL STORAGE ---
         function saveToLocalStorage() {
-            try {
-                const configString = JSON.stringify(configuration);
-                localStorage.setItem('3xlogicConfig', configString);
-            } catch (e) {
-                console.error("Failed to save to localStorage", e);
-            }
+            window.AppState.persistConfiguration(configuration);
         }
 
         function loadFromLocalStorage() {
-  // Small helpers to make sure we always work with arrays/objects
-  const toArray = (v) => {
-    if (Array.isArray(v)) return v;
-    if (v && typeof v === 'object') return Object.values(v); // migrate object maps -> arrays
-    return [];
-  };
-  const toObject = (v) => (v && typeof v === 'object' && !Array.isArray(v) ? v : {});
-
-  try {
-    const configString = localStorage.getItem('3xlogicConfig');
-    if (!configString) return false;
-
-    const loadedConfig = toObject(JSON.parse(configString));
-
-    // IMPORTANT: mutate the existing configuration object instead of replacing it,
-    // so other modules holding a reference don't break.
-    Object.assign(configuration, { layoutPlacements: [] }, loadedConfig);
-
-    // Normalize top-level collections
-    configuration.racks            = toArray(configuration.racks);
-    configuration.cloudServers     = toArray(configuration.cloudServers);
-    configuration.cloudCameras     = toArray(configuration.cloudCameras);
-    configuration.allInOneCameras  = toArray(configuration.allInOneCameras);
-    configuration.cameraLayout     = configuration.cameraLayout || null;
-
-    // Normalize nested racks/devices/cameras and NVR fields
-    configuration.racks.forEach((r) => {
-      r.standaloneSwitches = toArray(r.standaloneSwitches);
-      r.devices            = toArray(r.devices);
-
-      r.devices.forEach((d) => {
-        d.assignedUps = toArray(d.assignedUps);
-        d.cameras     = toArray(d.cameras);
-
-        if (d.product && d.product.deviceType === 'nvr') {
-          d.licenses = toArray(d.licenses);
-          if (typeof syncNvrLicenses === 'function') {
-            syncNvrLicenses(d);
-          }
+            return window.AppState.restoreConfiguration(configuration, {
+                syncNvrLicenses,
+                onSuccess: () => showToast('Project restored from last session.'),
+                onError: (error) => console.error('Failed to load from localStorage', error)
+            });
         }
-      });
-    });
-
-    // Fix/seed camera fields across ALL camera arrays (cloud / AIO / on-recorders)
-    const rackCameras = configuration.racks.flatMap((r) =>
-      r.devices.flatMap((d) => toArray(d.cameras))
-    );
-
-    const allCameraArrays = [configuration.cloudCameras, configuration.allInOneCameras, rackCameras];
-
-    allCameraArrays.forEach((camArray) => {
-      // Each member here is GUARANTEED an array now
-      camArray.forEach((c) => {
-        if (typeof c.location === 'undefined') c.location = '';
-        if (typeof c.quantity === 'undefined') c.quantity = 1;
-        if (c.isCloud && typeof c.selectedMounts === 'undefined') c.selectedMounts = [null];
-      });
-    });
-
-    if (typeof showToast === 'function') {
-      showToast('Project restored from last session.');
-    }
-    return true;
-  } catch (e) {
-    console.error('Failed to load from localStorage', e);
-    localStorage.removeItem('3xlogicConfig');
-    return false;
-  }
-}
 
         function saveProjectToFile() {
             const configString = JSON.stringify(configuration, null, 2);
@@ -2150,10 +2072,9 @@
                 try {
                     const configString = e.target.result;
                     const loadedConfig = JSON.parse(configString);
-                    configuration = {
-                        layoutPlacements: [],
-                        ...loadedConfig
-                    };
+                    window.AppState.applyDefaults(configuration);
+                    Object.assign(configuration, { layoutPlacements: [] }, loadedConfig);
+                    window.AppState.normalizeConfiguration(configuration, { syncNvrLicenses });
                     renderAll();
                     showToast("Project Loaded Successfully!");
                 } catch (err) {

--- a/vigilconfig/state-manager.js
+++ b/vigilconfig/state-manager.js
@@ -1,0 +1,162 @@
+(function(global) {
+  const STORAGE_KEY = '3xlogicConfig';
+
+  const DEFAULT_CONFIGURATION = {
+    projectName: '',
+    racks: [],
+    cloudServers: [],
+    cloudCameras: [],
+    allInOneCameras: [],
+    accessControl: [],
+    mounts: [],
+    accessories: [],
+    customParts: [],
+    cameraLayout: null,
+    layoutPlacements: [],
+    layoutWalls: []
+  };
+
+  function cloneDefaults() {
+    return JSON.parse(JSON.stringify(DEFAULT_CONFIGURATION));
+  }
+
+  function applyDefaults(target) {
+    const base = typeof target === 'object' && target !== null ? target : {};
+    const defaults = cloneDefaults();
+
+    Object.keys(base).forEach((key) => {
+      if (!Object.prototype.hasOwnProperty.call(defaults, key)) {
+        delete base[key];
+      }
+    });
+
+    return Object.assign(base, defaults);
+  }
+
+  function toArray(value) {
+    if (Array.isArray(value)) return value;
+    if (value && typeof value === 'object') return Object.values(value);
+    return [];
+  }
+
+  function ensureCameraDefaults(camera) {
+    if (!camera || typeof camera !== 'object') return;
+    if (typeof camera.location === 'undefined') camera.location = '';
+    if (typeof camera.quantity === 'undefined') camera.quantity = 1;
+    if (camera.isCloud && typeof camera.selectedMounts === 'undefined') {
+      camera.selectedMounts = [null];
+    }
+  }
+
+  function normalizeConfiguration(configuration, { syncNvrLicenses } = {}) {
+    configuration.projectName = configuration.projectName || '';
+    configuration.cameraLayout = configuration.cameraLayout || null;
+
+    configuration.racks = toArray(configuration.racks);
+    configuration.cloudServers = toArray(configuration.cloudServers);
+    configuration.cloudCameras = toArray(configuration.cloudCameras);
+    configuration.allInOneCameras = toArray(configuration.allInOneCameras);
+    configuration.accessControl = toArray(configuration.accessControl);
+    configuration.mounts = toArray(configuration.mounts);
+    configuration.accessories = toArray(configuration.accessories);
+    configuration.customParts = toArray(configuration.customParts);
+    configuration.layoutPlacements = toArray(configuration.layoutPlacements);
+    configuration.layoutWalls = toArray(configuration.layoutWalls);
+
+    configuration.racks.forEach((rack) => {
+      rack.standaloneSwitches = toArray(rack.standaloneSwitches);
+      rack.devices = toArray(rack.devices);
+
+      rack.devices.forEach((device) => {
+        device.assignedUps = toArray(device.assignedUps);
+        device.cameras = toArray(device.cameras);
+        device.storage = toArray(device.storage);
+        device.licenses = toArray(device.licenses);
+        device.poeSwitches = toArray(device.poeSwitches);
+        device.doors = toArray(device.doors);
+
+        if (device.product && device.product.deviceType === 'nvr' && typeof syncNvrLicenses === 'function') {
+          syncNvrLicenses(device);
+        }
+
+        device.cameras.forEach(ensureCameraDefaults);
+      });
+    });
+
+    const rackCameras = configuration.racks.flatMap((rack) =>
+      rack.devices.flatMap((device) => device.cameras || [])
+    );
+
+    [configuration.cloudCameras, configuration.allInOneCameras, rackCameras].forEach((collection) => {
+      collection.forEach(ensureCameraDefaults);
+    });
+
+    return configuration;
+  }
+
+  function createInitialConfiguration(existing) {
+    const target = applyDefaults(existing);
+    return normalizeConfiguration(target);
+  }
+
+  function resetConfiguration(configuration) {
+    applyDefaults(configuration);
+    normalizeConfiguration(configuration);
+    return configuration;
+  }
+
+  function persistConfiguration(configuration, storageKey = STORAGE_KEY) {
+    try {
+      const configString = JSON.stringify(configuration);
+      localStorage.setItem(storageKey, configString);
+      return true;
+    } catch (error) {
+      console.error('Failed to save to localStorage', error);
+      return false;
+    }
+  }
+
+  function restoreConfiguration(configuration, {
+    storageKey = STORAGE_KEY,
+    syncNvrLicenses,
+    onSuccess,
+    onError
+  } = {}) {
+    try {
+      const configString = localStorage.getItem(storageKey);
+      if (!configString) return false;
+
+      const parsedConfig = JSON.parse(configString);
+      if (!parsedConfig || typeof parsedConfig !== 'object') return false;
+
+      applyDefaults(configuration);
+      Object.assign(configuration, parsedConfig);
+      normalizeConfiguration(configuration, { syncNvrLicenses });
+
+      if (typeof onSuccess === 'function') {
+        onSuccess(configuration);
+      }
+
+      return true;
+    } catch (error) {
+      localStorage.removeItem(storageKey);
+      if (typeof onError === 'function') {
+        onError(error);
+      } else {
+        console.error('Failed to load from localStorage', error);
+      }
+      return false;
+    }
+  }
+
+  global.AppState = {
+    STORAGE_KEY,
+    DEFAULT_CONFIGURATION,
+    createInitialConfiguration,
+    resetConfiguration,
+    persistConfiguration,
+    restoreConfiguration,
+    normalizeConfiguration,
+    applyDefaults
+  };
+})(window);


### PR DESCRIPTION
## Summary
- add a reusable `state-manager.js` module that encapsulates configuration defaults, normalization, and persistence helpers
- update both copies of `index.html` to bootstrap configuration via the state manager and route reset/load/save flows through it
- ensure loading from files and localStorage mutates the existing configuration object so other modules retain their references

## Testing
- No automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dbdd7a40f083239da294991ce132c7