### PR TITLE
Fix broken inline script initialization

### DIFF
--- a/index.html
+++ b/index.html
@@ -2306,7 +2306,6 @@
         }
 
         function resetConfiguration() {
-        function resetConfiguration() {
             if(confirm('Are you sure you want to reset the entire configuration?')) {
                 window.AppState.resetConfiguration(configuration);
                 localStorage.removeItem(window.AppState.STORAGE_KEY);


### PR DESCRIPTION
## Summary
- remove the duplicated `resetConfiguration` declaration that left the inline script unbalanced
- allow the UI features and menus to initialize now that the script parses correctly

## Testing
- `node - <<'NODE'
const fs = require('fs');
const vm = require('vm');
const text = fs.readFileSync('index.html', 'utf8');
const start = text.indexOf('<script>') + '<script>'.length;
const end = text.lastIndexOf('</script>');
const script = text.slice(start, end);
new vm.Script(script);
console.log('Script parses successfully');
NODE`


------
https://chatgpt.com/codex/tasks/task_e_68dc4dec57d083239fef66dd29667bc1