### PR TITLE
Improve SMBK bundle handling and NVR metadata

### DIFF
--- a/index.html
+++ b/index.html
@@ -698,20 +698,128 @@
 
         let autoAddLicenses = true;
 
-        const smbkBundles = {
-            'NVR-1U-8CH-SMBK-4D': { storage: 4, cameras: [{ id: 'VX-SMBK-D-IW', qty: 4 }] },
-            'NVR-1U-8CH-SMBK-4B': { storage: 4, cameras: [{ id: 'VX-SMBK-B-IW', qty: 4 }] },
-            'NVR-1U-8CH-SMBK-2D2B': { storage: 4, cameras: [{ id: 'VX-SMBK-D-IW', qty: 2 }, { id: 'VX-SMBK-B-IW', qty: 2 }] },
-            'NVR-1U-8CH-SMBK-8D': { storage: 4, cameras: [{ id: 'VX-SMBK-D-IW', qty: 8 }] },
-            'NVR-1U-8CH-SMBK-8B': { storage: 4, cameras: [{ id: 'VX-SMBK-B-IW', qty: 8 }] },
-            'NVR-1U-8CH-SMBK-4D4B': { storage: 4, cameras: [{ id: 'VX-SMBK-D-IW', qty: 4 }, { id: 'VX-SMBK-B-IW', qty: 4 }] },
-            'NVR-1U-8CH-WIN-SMBK-4D': { storage: 4, cameras: [{ id: 'VX-SMBK-D-IW', qty: 4 }] },
-            'NVR-1U-8CH-WIN-SMBK-4B': { storage: 4, cameras: [{ id: 'VX-SMBK-B-IW', qty: 4 }] },
-            'NVR-1U-8CH-WIN-SMBK-2D2B': { storage: 4, cameras: [{ id: 'VX-SMBK-D-IW', qty: 2 }, { id: 'VX-SMBK-B-IW', qty: 2 }] },
-            'NVR-1U-8CH-WIN-SMBK-8D': { storage: 4, cameras: [{ id: 'VX-SMBK-D-IW', qty: 8 }] },
-            'NVR-1U-8CH-WIN-SMBK-8B': { storage: 4, cameras: [{ id: 'VX-SMBK-B-IW', qty: 8 }] },
-            'NVR-1U-8CH-WIN-SMBK-4D4B': { storage: 4, cameras: [{ id: 'VX-SMBK-D-IW', qty: 4 }, { id: 'VX-SMBK-B-IW', qty: 4 }] },
+        const SMBK_CAMERA_MAP = {
+            D: 'VX-SMBK-D-IW',
+            B: 'VX-SMBK-B-IW'
         };
+
+        const OS_SEGMENT_MAP = {
+            WIN: 'Windows',
+            WINDOWS: 'Windows',
+            LINUX: 'Linux',
+            LNX: 'Linux',
+            LIN: 'Linux',
+            L: 'Linux'
+        };
+
+        function parseSmbkBundleSegments(segments) {
+            if (!Array.isArray(segments) || segments.length === 0) return null;
+
+            const cameraToken = segments.find(seg => /(\d+)([DB])/i.test(seg));
+            if (!cameraToken) return null;
+
+            const matches = cameraToken.match(/(\d+)([DB])/gi) || [];
+            const cameras = matches.reduce((acc, token) => {
+                const parsed = /(\d+)([DB])/i.exec(token);
+                if (!parsed) return acc;
+                const qty = parseInt(parsed[1], 10);
+                const type = parsed[2].toUpperCase();
+                const cameraId = SMBK_CAMERA_MAP[type];
+                if (cameraId && qty > 0) {
+                    acc.push({ id: cameraId, qty });
+                }
+                return acc;
+            }, []);
+
+            if (cameras.length === 0) return null;
+
+            const osToken = segments.find(seg => OS_SEGMENT_MAP[seg.toUpperCase()]);
+
+            return {
+                cameras,
+                storageTb: 4,
+                storageDriveCount: 1,
+                os: osToken ? OS_SEGMENT_MAP[osToken.toUpperCase()] : null
+            };
+        }
+
+        function deriveNvrDetailsFromPartNumber(product) {
+            if (!product || typeof product.id !== 'string') return null;
+
+            const segments = product.id.split('-');
+            if (segments[0] !== 'NVR') return null;
+
+            const metadata = {};
+
+            for (let i = 1; i < segments.length; i++) {
+                const segment = segments[i];
+                const upper = segment.toUpperCase();
+
+                if (/^\d+U$/.test(upper)) {
+                    metadata.size = upper;
+                } else if (/^\d+CH$/.test(upper)) {
+                    metadata.channels = parseInt(upper.replace('CH', ''), 10);
+                } else if (/^\d+IP$/.test(upper)) {
+                    metadata.prefilledLicenses = parseInt(upper.replace('IP', ''), 10);
+                } else if (/^\d+(?:\.\d+)?TB$/.test(upper)) {
+                    metadata.storageTb = parseFloat(upper.replace('TB', ''));
+                } else if (OS_SEGMENT_MAP[upper]) {
+                    metadata.operatingSystem = OS_SEGMENT_MAP[upper];
+                } else if (upper === 'SMBK') {
+                    const bundleInfo = parseSmbkBundleSegments(segments.slice(i + 1));
+                    if (bundleInfo) {
+                        metadata.bundleCameras = bundleInfo.cameras;
+                        metadata.bundleStorageTb = bundleInfo.storageTb;
+                        metadata.bundleStorageDriveCount = bundleInfo.storageDriveCount;
+                        if (bundleInfo.os && !metadata.operatingSystem) {
+                            metadata.operatingSystem = bundleInfo.os;
+                        }
+                    }
+                    break;
+                }
+            }
+
+            if (metadata.bundleStorageTb && !metadata.bundleStorageDriveCount) {
+                metadata.bundleStorageDriveCount = Math.max(1, Math.round(metadata.bundleStorageTb / 4));
+            }
+
+            return metadata;
+        }
+
+        function applyDerivedMetadataToProducts(productTree) {
+            const traverse = (collection) => {
+                if (Array.isArray(collection)) {
+                    collection.forEach(product => {
+                        if (!product || typeof product !== 'object') return;
+                        if (product.deviceType !== 'nvr') return;
+
+                        const metadata = deriveNvrDetailsFromPartNumber(product);
+                        if (!metadata) return;
+
+                        if (metadata.size) product.size = metadata.size;
+                        if (metadata.channels) product.channels = metadata.channels;
+                        if (metadata.prefilledLicenses) product.prefilledLicenses = metadata.prefilledLicenses;
+                        if (metadata.bundleStorageTb) product.bundleStorageTb = metadata.bundleStorageTb;
+                        if (metadata.bundleStorageDriveCount) product.bundleStorageDriveCount = metadata.bundleStorageDriveCount;
+                        if (metadata.bundleCameras && (!Array.isArray(product.includedCameras) || product.includedCameras.length === 0)) {
+                            product.includedCameras = metadata.bundleCameras.map(({ id, qty }) => ({ productId: id, quantity: qty }));
+                        }
+                    });
+                } else if (collection && typeof collection === 'object') {
+                    Object.values(collection).forEach(traverse);
+                }
+            };
+
+            traverse(productTree);
+        }
+
+        applyDerivedMetadataToProducts(products);
+
+        function hasBuiltInStorage(product) {
+            if (!product || typeof product !== 'object') return false;
+            if (product.bundleStorageTb && product.bundleStorageTb > 0) return true;
+            return typeof product.id === 'string' && product.id.includes('TB');
+        }
 
         // --- DOM ELEMENT REFERENCES ---
         const summaryEl = document.getElementById('configSummary');
@@ -1094,25 +1202,6 @@
                     };
                     if (product.deviceType === 'nvr') {
                         newDevice.isCamerasExpanded = true;
-                        // Check for SMBK bundle
-                        if (smbkBundles[product.id]) {
-                            const bundle = smbkBundles[product.id];
-                            bundle.cameras.forEach(camInfo => {
-                                const camProductInfo = findProductById(camInfo.id);
-                                if (camProductInfo) {
-                                    for (let i = 0; i < camInfo.qty; i++) {
-                                        newDevice.cameras.push({ 
-                                            ...camProductInfo.product, 
-                                            quantity: 1, 
-                                            instanceId: Date.now() + i, 
-                                            isBundleCamera: true, 
-                                            selectedMounts: [null], 
-                                            location: '' 
-                                        });
-                                    }
-                                }
-                            });
-                        }
                         // Check for the generic 'includedCameras' property
                         if (Array.isArray(product.includedCameras)) {
                             product.includedCameras.forEach(camInfo => {
@@ -1722,7 +1811,8 @@
                     if (device.product.deviceType === 'nvr') {
                         const availablePorts = getAvailablePorts(device);
                         const cameraCount = getNvrChannelUsage(device);
-                        const storageCount = device.storage.reduce((acc, s) => acc + s.quantity, 0) + (smbkBundles[device.product.id] ? smbkBundles[device.product.id].storage / 4 : 0);
+                        const includedStorageDrives = device.product.bundleStorageDriveCount || 0;
+                        const storageCount = device.storage.reduce((acc, s) => acc + s.quantity, 0) + includedStorageDrives;
                         const poeLoad = device.cameras.reduce((acc, cam) => acc + (cam.assignedInjectorId ? 0 : (cam.poe * cam.quantity)), 0);
                         
                         let licenseHtml = '';
@@ -2649,7 +2739,7 @@
                     if (device.product.maxStorage && storageCount > device.product.maxStorage) {
                         warnings.push({ type: 'error', title: 'Storage Bays Exceeded', message: `NVR "${device.product.name}" has ${storageCount} drives, exceeding its limit of ${device.product.maxStorage}.` });
                     }
-                    if (!device.product.id.includes('TB') && device.storage.length === 0 && !smbkBundles[device.product.id]) {
+                    if (!hasBuiltInStorage(device.product) && device.storage.length === 0) {
                          warnings.push({ type: 'warning', title: 'Storage Recommended', message: `NVR "${device.product.name}" does not include storage. Consider adding a hard drive.` });
                     }
                 }

--- a/vigilconfig/index.html
+++ b/vigilconfig/index.html
@@ -698,20 +698,128 @@
 
         let autoAddLicenses = true;
 
-        const smbkBundles = {
-            'NVR-1U-8CH-SMBK-4D': { storage: 4, cameras: [{ id: 'VX-SMBK-D-IW', qty: 4 }] },
-            'NVR-1U-8CH-SMBK-4B': { storage: 4, cameras: [{ id: 'VX-SMBK-B-IW', qty: 4 }] },
-            'NVR-1U-8CH-SMBK-2D2B': { storage: 4, cameras: [{ id: 'VX-SMBK-D-IW', qty: 2 }, { id: 'VX-SMBK-B-IW', qty: 2 }] },
-            'NVR-1U-8CH-SMBK-8D': { storage: 4, cameras: [{ id: 'VX-SMBK-D-IW', qty: 8 }] },
-            'NVR-1U-8CH-SMBK-8B': { storage: 4, cameras: [{ id: 'VX-SMBK-B-IW', qty: 8 }] },
-            'NVR-1U-8CH-SMBK-4D4B': { storage: 4, cameras: [{ id: 'VX-SMBK-D-IW', qty: 4 }, { id: 'VX-SMBK-B-IW', qty: 4 }] },
-            'NVR-1U-8CH-WIN-SMBK-4D': { storage: 4, cameras: [{ id: 'VX-SMBK-D-IW', qty: 4 }] },
-            'NVR-1U-8CH-WIN-SMBK-4B': { storage: 4, cameras: [{ id: 'VX-SMBK-B-IW', qty: 4 }] },
-            'NVR-1U-8CH-WIN-SMBK-2D2B': { storage: 4, cameras: [{ id: 'VX-SMBK-D-IW', qty: 2 }, { id: 'VX-SMBK-B-IW', qty: 2 }] },
-            'NVR-1U-8CH-WIN-SMBK-8D': { storage: 4, cameras: [{ id: 'VX-SMBK-D-IW', qty: 8 }] },
-            'NVR-1U-8CH-WIN-SMBK-8B': { storage: 4, cameras: [{ id: 'VX-SMBK-B-IW', qty: 8 }] },
-            'NVR-1U-8CH-WIN-SMBK-4D4B': { storage: 4, cameras: [{ id: 'VX-SMBK-D-IW', qty: 4 }, { id: 'VX-SMBK-B-IW', qty: 4 }] },
+        const SMBK_CAMERA_MAP = {
+            D: 'VX-SMBK-D-IW',
+            B: 'VX-SMBK-B-IW'
         };
+
+        const OS_SEGMENT_MAP = {
+            WIN: 'Windows',
+            WINDOWS: 'Windows',
+            LINUX: 'Linux',
+            LNX: 'Linux',
+            LIN: 'Linux',
+            L: 'Linux'
+        };
+
+        function parseSmbkBundleSegments(segments) {
+            if (!Array.isArray(segments) || segments.length === 0) return null;
+
+            const cameraToken = segments.find(seg => /(\d+)([DB])/i.test(seg));
+            if (!cameraToken) return null;
+
+            const matches = cameraToken.match(/(\d+)([DB])/gi) || [];
+            const cameras = matches.reduce((acc, token) => {
+                const parsed = /(\d+)([DB])/i.exec(token);
+                if (!parsed) return acc;
+                const qty = parseInt(parsed[1], 10);
+                const type = parsed[2].toUpperCase();
+                const cameraId = SMBK_CAMERA_MAP[type];
+                if (cameraId && qty > 0) {
+                    acc.push({ id: cameraId, qty });
+                }
+                return acc;
+            }, []);
+
+            if (cameras.length === 0) return null;
+
+            const osToken = segments.find(seg => OS_SEGMENT_MAP[seg.toUpperCase()]);
+
+            return {
+                cameras,
+                storageTb: 4,
+                storageDriveCount: 1,
+                os: osToken ? OS_SEGMENT_MAP[osToken.toUpperCase()] : null
+            };
+        }
+
+        function deriveNvrDetailsFromPartNumber(product) {
+            if (!product || typeof product.id !== 'string') return null;
+
+            const segments = product.id.split('-');
+            if (segments[0] !== 'NVR') return null;
+
+            const metadata = {};
+
+            for (let i = 1; i < segments.length; i++) {
+                const segment = segments[i];
+                const upper = segment.toUpperCase();
+
+                if (/^\d+U$/.test(upper)) {
+                    metadata.size = upper;
+                } else if (/^\d+CH$/.test(upper)) {
+                    metadata.channels = parseInt(upper.replace('CH', ''), 10);
+                } else if (/^\d+IP$/.test(upper)) {
+                    metadata.prefilledLicenses = parseInt(upper.replace('IP', ''), 10);
+                } else if (/^\d+(?:\.\d+)?TB$/.test(upper)) {
+                    metadata.storageTb = parseFloat(upper.replace('TB', ''));
+                } else if (OS_SEGMENT_MAP[upper]) {
+                    metadata.operatingSystem = OS_SEGMENT_MAP[upper];
+                } else if (upper === 'SMBK') {
+                    const bundleInfo = parseSmbkBundleSegments(segments.slice(i + 1));
+                    if (bundleInfo) {
+                        metadata.bundleCameras = bundleInfo.cameras;
+                        metadata.bundleStorageTb = bundleInfo.storageTb;
+                        metadata.bundleStorageDriveCount = bundleInfo.storageDriveCount;
+                        if (bundleInfo.os && !metadata.operatingSystem) {
+                            metadata.operatingSystem = bundleInfo.os;
+                        }
+                    }
+                    break;
+                }
+            }
+
+            if (metadata.bundleStorageTb && !metadata.bundleStorageDriveCount) {
+                metadata.bundleStorageDriveCount = Math.max(1, Math.round(metadata.bundleStorageTb / 4));
+            }
+
+            return metadata;
+        }
+
+        function applyDerivedMetadataToProducts(productTree) {
+            const traverse = (collection) => {
+                if (Array.isArray(collection)) {
+                    collection.forEach(product => {
+                        if (!product || typeof product !== 'object') return;
+                        if (product.deviceType !== 'nvr') return;
+
+                        const metadata = deriveNvrDetailsFromPartNumber(product);
+                        if (!metadata) return;
+
+                        if (metadata.size) product.size = metadata.size;
+                        if (metadata.channels) product.channels = metadata.channels;
+                        if (metadata.prefilledLicenses) product.prefilledLicenses = metadata.prefilledLicenses;
+                        if (metadata.bundleStorageTb) product.bundleStorageTb = metadata.bundleStorageTb;
+                        if (metadata.bundleStorageDriveCount) product.bundleStorageDriveCount = metadata.bundleStorageDriveCount;
+                        if (metadata.bundleCameras && (!Array.isArray(product.includedCameras) || product.includedCameras.length === 0)) {
+                            product.includedCameras = metadata.bundleCameras.map(({ id, qty }) => ({ productId: id, quantity: qty }));
+                        }
+                    });
+                } else if (collection && typeof collection === 'object') {
+                    Object.values(collection).forEach(traverse);
+                }
+            };
+
+            traverse(productTree);
+        }
+
+        applyDerivedMetadataToProducts(products);
+
+        function hasBuiltInStorage(product) {
+            if (!product || typeof product !== 'object') return false;
+            if (product.bundleStorageTb && product.bundleStorageTb > 0) return true;
+            return typeof product.id === 'string' && product.id.includes('TB');
+        }
 
         // --- DOM ELEMENT REFERENCES ---
         const summaryEl = document.getElementById('configSummary');
@@ -1094,25 +1202,6 @@
                     };
                     if (product.deviceType === 'nvr') {
                         newDevice.isCamerasExpanded = true;
-                        // Check for SMBK bundle
-                        if (smbkBundles[product.id]) {
-                            const bundle = smbkBundles[product.id];
-                            bundle.cameras.forEach(camInfo => {
-                                const camProductInfo = findProductById(camInfo.id);
-                                if (camProductInfo) {
-                                    for (let i = 0; i < camInfo.qty; i++) {
-                                        newDevice.cameras.push({ 
-                                            ...camProductInfo.product, 
-                                            quantity: 1, 
-                                            instanceId: Date.now() + i, 
-                                            isBundleCamera: true, 
-                                            selectedMounts: [null], 
-                                            location: '' 
-                                        });
-                                    }
-                                }
-                            });
-                        }
                         // Check for the generic 'includedCameras' property
                         if (Array.isArray(product.includedCameras)) {
                             product.includedCameras.forEach(camInfo => {
@@ -1722,7 +1811,8 @@
                     if (device.product.deviceType === 'nvr') {
                         const availablePorts = getAvailablePorts(device);
                         const cameraCount = getNvrChannelUsage(device);
-                        const storageCount = device.storage.reduce((acc, s) => acc + s.quantity, 0) + (smbkBundles[device.product.id] ? smbkBundles[device.product.id].storage / 4 : 0);
+                        const includedStorageDrives = device.product.bundleStorageDriveCount || 0;
+                        const storageCount = device.storage.reduce((acc, s) => acc + s.quantity, 0) + includedStorageDrives;
                         const poeLoad = device.cameras.reduce((acc, cam) => acc + (cam.assignedInjectorId ? 0 : (cam.poe * cam.quantity)), 0);
                         
                         let licenseHtml = '';
@@ -2649,7 +2739,7 @@
                     if (device.product.maxStorage && storageCount > device.product.maxStorage) {
                         warnings.push({ type: 'error', title: 'Storage Bays Exceeded', message: `NVR "${device.product.name}" has ${storageCount} drives, exceeding its limit of ${device.product.maxStorage}.` });
                     }
-                    if (!device.product.id.includes('TB') && device.storage.length === 0 && !smbkBundles[device.product.id]) {
+                    if (!hasBuiltInStorage(device.product) && device.storage.length === 0) {
                          warnings.push({ type: 'warning', title: 'Storage Recommended', message: `NVR "${device.product.name}" does not include storage. Consider adding a hard drive.` });
                     }
                 }


### PR DESCRIPTION
## Summary
- derive recorder size, channel, license, and bundle camera details from NVR part numbers so SMBK kits populate automatically
- store bundle storage metadata on products and reuse it in the visualizer and system status warnings
- rely on the generic includedCameras flow, removing the static SMBK bundle map in both app shells

## Testing
- Not run (UI changes only)

------
https://chatgpt.com/codex/tasks/task_e_68ddd52f825c8323b727c1cc5d0b14e9