### PR TITLE
Align SMBK and SUSA camera bundle handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -742,6 +742,11 @@
             B: 'VX-SMBK-B-IW'
         };
 
+        const SUSA_CAMERA_MAP = {
+            D: 'VX-5M-OD-RIAW-X',
+            B: 'VX-5M-B-RIAW-X'
+        };
+
         const OS_SEGMENT_MAP = {
             WIN: 'Windows',
             WINDOWS: 'Windows',
@@ -782,13 +787,54 @@
             };
         }
 
+        function parseSusaBundleSegments(segments) {
+            if (!Array.isArray(segments) || segments.length === 0) return null;
+
+            const matches = segments.reduce((acc, segment) => {
+                const tokens = segment.match(/([DB])(\d+)/gi) || [];
+                return acc.concat(tokens);
+            }, []);
+
+            if (matches.length === 0) return null;
+
+            const cameras = matches.reduce((acc, token) => {
+                const parsed = /([DB])(\d+)/i.exec(token);
+                if (!parsed) return acc;
+                const type = parsed[1].toUpperCase();
+                const qty = parseInt(parsed[2], 10);
+                const cameraId = SUSA_CAMERA_MAP[type];
+                if (cameraId && qty > 0) {
+                    acc.push({ id: cameraId, qty });
+                }
+                return acc;
+            }, []);
+
+            if (cameras.length === 0) return null;
+
+            return { cameras };
+        }
+
         function deriveNvrDetailsFromPartNumber(product) {
             if (!product || typeof product.id !== 'string') return null;
 
             const segments = product.id.split('-');
-            if (segments[0] !== 'NVR') return null;
+            const prefix = segments[0].toUpperCase();
+            const isSusaBundle = prefix === 'SUSA';
+            if (!isSusaBundle && prefix !== 'NVR') return null;
 
             const metadata = {};
+
+            if (Array.isArray(product.includedCameras) && product.includedCameras.length > 0) {
+                metadata.bundleCameras = product.includedCameras.map(({ productId, quantity }) => ({
+                    id: productId,
+                    qty: Number(quantity) || 1
+                }));
+            }
+
+            if (typeof product.includedStorage === 'number') {
+                metadata.bundleStorageTb = product.includedStorage;
+                metadata.bundleStorageDriveCount = Math.max(1, Math.round(metadata.bundleStorageTb / 4));
+            }
 
             for (let i = 1; i < segments.length; i++) {
                 const segment = segments[i];
@@ -805,13 +851,23 @@
                 } else if (OS_SEGMENT_MAP[upper]) {
                     metadata.operatingSystem = OS_SEGMENT_MAP[upper];
                 } else if (upper === 'SMBK') {
-                    const bundleInfo = parseSmbkBundleSegments(segments.slice(i + 1));
-                    if (bundleInfo) {
-                        metadata.bundleCameras = bundleInfo.cameras;
-                        metadata.bundleStorageTb = bundleInfo.storageTb;
-                        metadata.bundleStorageDriveCount = bundleInfo.storageDriveCount;
-                        if (bundleInfo.os && !metadata.operatingSystem) {
-                            metadata.operatingSystem = bundleInfo.os;
+                    if (!metadata.bundleCameras) {
+                        const bundleInfo = parseSmbkBundleSegments(segments.slice(i + 1));
+                        if (bundleInfo) {
+                            metadata.bundleCameras = bundleInfo.cameras;
+                            metadata.bundleStorageTb = bundleInfo.storageTb;
+                            metadata.bundleStorageDriveCount = bundleInfo.storageDriveCount;
+                            if (bundleInfo.os && !metadata.operatingSystem) {
+                                metadata.operatingSystem = bundleInfo.os;
+                            }
+                        }
+                    }
+                    break;
+                } else if (isSusaBundle && upper === 'BNDL') {
+                    if (!metadata.bundleCameras) {
+                        const bundleInfo = parseSusaBundleSegments(segments.slice(i + 1));
+                        if (bundleInfo) {
+                            metadata.bundleCameras = bundleInfo.cameras;
                         }
                     }
                     break;


### PR DESCRIPTION
## Summary
- restore SMBK camera token mapping to the SMBK kit camera IDs and add a SUSA bundle camera map for the X-series cameras
- add SUSA bundle parsing fallback and allow metadata derivation for SUSA IDs while still preferring the catalog-defined bundle data

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68deab5ba888832385bdb0e97c35e146